### PR TITLE
F/plot bounds

### DIFF
--- a/src/components/modebar/buttons.js
+++ b/src/components/modebar/buttons.js
@@ -15,6 +15,7 @@ var Axes = require('../../plots/cartesian/axes');
 var Lib = require('../../lib');
 var downloadImage = require('../../snapshot/download');
 var Icons = require('../../../build/ploticon');
+var clampRangeToBounds = require('../../lib/clamp_range_to_bounds');
 
 
 var modeBarButtons = module.exports = {};
@@ -205,8 +206,19 @@ function handleCartesian(gd, ev) {
                 }
                 else {
                     var rangeNow = ax.range;
-                    aobj[axName + '.range[0]'] = r0 * rangeNow[0] + r1 * rangeNow[1];
-                    aobj[axName + '.range[1]'] = r0 * rangeNow[1] + r1 * rangeNow[0];
+                    
+                    if(ax.boundsmode == 'auto' && !ax.bounds){
+                        ax.bounds = Axes.getAutoRange(ax);
+                        aobj[axName + '.bounds'] = ax.bounds;
+                    }
+                    
+                    var newRange = clampRangeToBounds([
+                        r0 * rangeNow[0] + r1 * rangeNow[1],
+                        r0 * rangeNow[1] + r1 * rangeNow[0]
+                    ], ax.bounds);
+                    
+                    aobj[axName + '.range[0]'] = newRange[0];
+                    aobj[axName + '.range[1]'] = newRange[1];
                 }
             }
         }

--- a/src/lib/clamp_range_to_bounds.js
+++ b/src/lib/clamp_range_to_bounds.js
@@ -1,0 +1,43 @@
+/**
+* Copyright 2012-2016, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+
+'use strict';
+
+/**
+ * Clamps a given range to the bounds specified.
+ * @param {array} range to clamp to the bounds.
+ * @param {array} bounds to clamp to.
+ * @return {array} clamped range, where limits are 
+ *     always inside bounds. range size is maintained, unless
+ *     bigger than bounds size.
+ */
+module.exports = function clampRangeToBounds(range, bounds) {
+    if(!bounds) {
+        return range;
+    }
+
+    var r1 = range[0], r2 = range[1];
+    var dr = r2 - r1;
+
+    var b1 = bounds[0];
+    var b2 = bounds[1];
+    var db = b2 - b1;
+    if(dr > db) {
+        dr = db;
+    }
+    if(r1 < b1) {
+        r2 = b1 + dr;
+        r1 = b1;
+    } else if(r2 > b2) {
+        r1 = b2 - dr;
+        r2 = b2;
+    }
+
+    return [r1, r2];
+};

--- a/src/plots/cartesian/axis_defaults.js
+++ b/src/plots/cartesian/axis_defaults.js
@@ -103,6 +103,8 @@ module.exports = function handleAxisDefaults(containerIn, containerOut, coerce, 
     Lib.noneOrAll(containerIn.range, containerOut.range, [0, 1]);
 
     coerce('fixedrange');
+    coerce('bounds');
+    coerce('boundsmode');
 
     handleTickValueDefaults(containerIn, containerOut, coerce, axType);
     handleTickLabelDefaults(containerIn, containerOut, coerce, axType, options);

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -430,13 +430,52 @@ module.exports = function dragBox(gd, plotinfo, x, y, w, h, ns, ew) {
         else if(dragger.onmousewheel !== undefined) dragger.onmousewheel = zoomWheel;
     }
 
+    function computeAxisBounds(axi) {
+        var plotAxis = dragOptions.plotinfo[axi._name];
+        return Axes.getAutoRange(plotAxis);
+    }
+
+    function clampRangeToBounds(range, bounds) {
+        if(!bounds) {
+            return range;
+        }
+
+        var r1 = range[0], r2 = range[1];
+        var dr = r2 - r1;
+
+        var b1 = bounds[0];
+        var b2 = bounds[1];
+        var db = b2 - b1;
+        if(dr > db) {
+            dr = db;
+        }
+        if(r1 < b1) {
+            r2 = b1 + dr;
+            r1 = b1;
+        } else if(r2 > b2) {
+            r1 = b2 - dr;
+            r2 = b2;
+        }
+
+        return [r1, r2];
+    }
+
     // plotDrag: move the plot in response to a drag
     function plotDrag(dx, dy) {
         function dragAxList(axList, pix) {
             for(var i = 0; i < axList.length; i++) {
                 var axi = axList[i];
                 if(!axi.fixedrange) {
-                    axi.range = [axi._r[0] - pix / axi._m, axi._r[1] - pix / axi._m];
+                    if(axi.boundsmode === 'auto' && !axi.bounds) {
+                        axi.bounds = computeAxisBounds(axi);
+                    }
+
+                    axi.range = clampRangeToBounds(
+                        [axi._r[0] - pix / axi._m, axi._r[1] - pix / axi._m],
+                        axi.bounds
+                    );
+
+                    avgdpix += (axi._r[0] - axi.range[0] + axi._r[1] - axi.range[1]) * axi._m / 2;
                 }
             }
         }

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -20,6 +20,7 @@ var Color = require('../../components/color');
 var Drawing = require('../../components/drawing');
 var setCursor = require('../../lib/setcursor');
 var dragElement = require('../../components/dragelement');
+var clampRangeToBounds = require('../../lib/clamp_range_to_bounds');
 
 var Axes = require('./axes');
 var prepSelect = require('./select');
@@ -434,31 +435,6 @@ module.exports = function dragBox(gd, plotinfo, x, y, w, h, ns, ew) {
     function computeAxisBounds(axi) {
         var plotAxis = dragOptions.plotinfo[axi._name];
         return Axes.getAutoRange(plotAxis);
-    }
-
-    function clampRangeToBounds(range, bounds) {
-        if(!bounds) {
-            return range;
-        }
-
-        var r1 = range[0], r2 = range[1];
-        var dr = r2 - r1;
-
-        var b1 = bounds[0];
-        var b2 = bounds[1];
-        var db = b2 - b1;
-        if(dr > db) {
-            dr = db;
-        }
-        if(r1 < b1) {
-            r2 = b1 + dr;
-            r1 = b1;
-        } else if(r2 > b2) {
-            r1 = b2 - dr;
-            r2 = b2;
-        }
-
-        return [r1, r2];
     }
 
     // plotDrag: move the plot in response to a drag

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -463,6 +463,7 @@ module.exports = function dragBox(gd, plotinfo, x, y, w, h, ns, ew) {
     // plotDrag: move the plot in response to a drag
     function plotDrag(dx, dy) {
         function dragAxList(axList, pix) {
+            var avgdpix = 0;
             for(var i = 0; i < axList.length; i++) {
                 var axi = axList[i];
                 if(!axi.fixedrange) {
@@ -478,11 +479,12 @@ module.exports = function dragBox(gd, plotinfo, x, y, w, h, ns, ew) {
                     avgdpix += (axi._r[0] - axi.range[0] + axi._r[1] - axi.range[1]) * axi._m / 2;
                 }
             }
+            return avgdpix / (axList.length || 1);
         }
 
         if(xActive === 'ew' || yActive === 'ns') {
-            if(xActive) dragAxList(xa, dx);
-            if(yActive) dragAxList(ya, dy);
+            if(xActive) dx = dragAxList(xa, dx);
+            if(yActive) dy = dragAxList(ya, dy);
             updateSubplots([xActive ? -dx : 0, yActive ? -dy : 0, pw, ph]);
             ticksAndAnnotations(yActive, xActive);
             return;

--- a/src/plots/cartesian/layout_attributes.js
+++ b/src/plots/cartesian/layout_attributes.js
@@ -95,6 +95,30 @@ module.exports = {
         ].join(' ')
     },
 
+    bounds: {
+        valType: 'info_array',
+        role: 'info',
+        items: [
+            {valType: 'number'},
+            {valType: 'number'}
+        ],
+        description: [
+            'Sets the maximum and minimum bounds of this axis.',
+            'If set, the plot cannot show anything outside this region.'
+        ].join(' ')
+    },
+    
+    boundsmode: {
+        valType: 'enumerated',
+        values: ['normal', 'auto'],
+        dflt: 'normal',
+        role: 'style',
+        description: [
+            'If *normal*, the bounds range is used is set, and not used otherwise.',
+            'If *auto*, the range autocomputation is used as the bounds range.',
+        ].join(' ')
+    },
+
     fixedrange: {
         valType: 'boolean',
         dflt: false,

--- a/src/plots/cartesian/layout_attributes.js
+++ b/src/plots/cartesian/layout_attributes.js
@@ -107,7 +107,7 @@ module.exports = {
             'If set, the plot cannot show anything outside this region.'
         ].join(' ')
     },
-    
+
     boundsmode: {
         valType: 'enumerated',
         values: ['normal', 'auto'],

--- a/src/plots/gl3d/layout/axis_attributes.js
+++ b/src/plots/gl3d/layout/axis_attributes.js
@@ -77,6 +77,8 @@ module.exports = {
     rangemode: axesAttrs.rangemode,
     range: axesAttrs.range,
     fixedrange: axesAttrs.fixedrange,
+    bounds: axesAttrs.bounds,
+    boundsmode: axesAttrs.boundsmode,
     // ticks
     tickmode: axesAttrs.tickmode,
     nticks: axesAttrs.nticks,

--- a/test/image/mocks/axis_bounds.json
+++ b/test/image/mocks/axis_bounds.json
@@ -1,0 +1,44 @@
+{
+  "data": [
+    {
+      "x": [
+        1,
+        2,
+        3,
+        4
+      ],
+      "y": [
+        10,
+        15,
+        13,
+        17
+      ],
+      "type": "scatter"
+    },
+    {
+      "x": [
+        1,
+        2,
+        3,
+        4
+      ],
+      "y": [
+        16,
+        5,
+        11,
+        9
+      ],
+      "type": "scatter"
+    }
+  ],
+  "layout": {
+    "xaxis": {
+      "boundsmode":"auto"
+    },
+    "yaxis": {
+      "bounds": [0, 1e99],
+      "boundsmode":"normal"
+    }
+  }
+
+}


### PR DESCRIPTION
This pull request is for constraining the plot ranges so that they are interactive,  but don't allow the user to scroll past some specified bounds.

To do this, two new layout properties are added to the axes:
    - `bounds`   - for specifying that the axis should be contrained to always be within that range
    - `boundsmode` - for specifying wether bounds is computed manually or automatically.
To implement the functionality, a new file is added in `src/lib/clamp_range_to_bounds.js` with the function `clampRangeToBounds` that contains the bounds restricting logic. The panning and zooming logic in `src/plots/cartesian/dragbox.js` and `src/components/modebar/buttons.js` is then altered to restrict the modified ranges to `bounds` using `clampRangeToBounds`, optionally computing the bounds on the spot if `boundsmode` is `'auto'`.

A mock is added in `test/image/mocks/axis_bounds.json` to test the functionality of these two attributes.
